### PR TITLE
API Authentication using Okta Auth0 [DO NOT MERGE]

### DIFF
--- a/Controllers/MyController.cs
+++ b/Controllers/MyController.cs
@@ -2,20 +2,24 @@ using Microsoft.AspNetCore.Mvc;
 using Twilio;
 using Twilio.Rest.Verify.V2.Service;
 using dotenv.net;
+using Microsoft.AspNetCore.Authorization;
 
 namespace SimpleWebAppReact.Controllers
-{
+{   
+
     [ApiController]
     [Route("api/[controller]")]
     public class MyController : ControllerBase
     {
         [HttpGet("message")] // Define the route for this action
+        [Authorize]
         public IActionResult GetMessage()
         {
             return Ok(new { message = "Hello from ASP.NET Core!" });
         }
 
         // Send Twillio Verification Email
+
         [HttpGet("send-verification-email")]
         public async Task<IActionResult> SendVerificationEmail()
         {

--- a/Controllers/MyController.cs
+++ b/Controllers/MyController.cs
@@ -1,4 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
+using Twilio;
+using Twilio.Rest.Verify.V2.Service;
+using dotenv.net;
 
 namespace SimpleWebAppReact.Controllers
 {
@@ -11,5 +14,44 @@ namespace SimpleWebAppReact.Controllers
         {
             return Ok(new { message = "Hello from ASP.NET Core!" });
         }
+
+        // Send Twillio Verification Email
+        [HttpGet("send-verification-email")]
+        public async Task<IActionResult> SendVerificationEmail()
+        {
+            DotEnv.Load();
+
+            string accountSid = Environment.GetEnvironmentVariable("TWILLIO_ACCOUNT_SID");
+
+            Console.WriteLine(accountSid);
+
+            string authToken = Environment.GetEnvironmentVariable("TWILLIO_AUTH_TOKEN");
+            string testRecipient = Environment.GetEnvironmentVariable("TEST_RECIPIENT");
+            string templateId = Environment.GetEnvironmentVariable("TWILLIO_TEMPLATE_ID");
+            string testName = Environment.GetEnvironmentVariable("TEST_NAME");
+            string serviceSid = Environment.GetEnvironmentVariable("TWILLIO_SERVICE_SID");
+
+            TwilioClient.Init(accountSid, authToken);
+
+            var verification = await VerificationResource.CreateAsync(
+                channel: "email",
+                to: testRecipient,
+                channelConfiguration: new Dictionary<
+                    string,
+                    Object>() { { "template_id", templateId }, { "from", testRecipient }, { "from_name", testName } },
+                pathServiceSid: serviceSid);
+
+            Console.WriteLine(verification.Sid);
+            if (verification.Status == "pending")
+            {
+                return Ok(new { message = "Verification email sent successfully" });
+            }
+            else
+            {
+                return BadRequest(new { message = "Failed to send verification email" });
+            }
+        }
     }
+
+
 }

--- a/HasScopeHandler.cs
+++ b/HasScopeHandler.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Authorization;
+namespace SimpleWebAppReact;
+public class HasScopeHandler : AuthorizationHandler<HasScopeRequirement>
+{
+  protected override Task HandleRequirementAsync(
+    AuthorizationHandlerContext context,
+    HasScopeRequirement requirement
+  ) {
+    // If user does not have the scope claim, get out of here
+    if (!context.User.HasClaim(c => c.Type == "scope" && c.Issuer == requirement.Issuer))
+      return Task.CompletedTask;
+
+
+    // Split the scopes string into an array
+    var scopes = context.User
+      .FindFirst(c => c.Type == "scope" && c.Issuer == requirement.Issuer).Value.Split(' ');
+
+    // Succeed if the scope array contains the required scope
+    if (scopes.Any(s => s == requirement.Scope))
+      context.Succeed(requirement);
+
+    return Task.CompletedTask;
+  }
+}

--- a/HasScopeRequirement.cs
+++ b/HasScopeRequirement.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Authorization;
+
+public class HasScopeRequirement : IAuthorizationRequirement
+{
+    public string Issuer { get; }
+    public string Scope { get; }
+
+    public HasScopeRequirement(string scope, string issuer)
+    {
+        Scope = scope ?? throw new ArgumentNullException(nameof(scope));
+        Issuer = issuer ?? throw new ArgumentNullException(nameof(issuer));
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,8 @@
-using System.Diagnostics;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.Tokens;
+using SimpleWebAppReact;
 using SimpleWebAppReact.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -11,6 +15,21 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<MongoDbService>();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+.AddJwtBearer(options =>
+{
+    options.Authority = "https://dev-mkdb0weeluguzopu.us.auth0.com/";
+    options.Audience = "http://localhost:5128";
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        NameClaimType = ClaimTypes.NameIdentifier
+    };
+});
+
+builder.Services.AddAuthorization();
+builder.Services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
+
 
 var app = builder.Build();
 

--- a/Program.cs
+++ b/Program.cs
@@ -29,7 +29,8 @@ app.UseStaticFiles();
 app.UseRouting();
 
 app.UseCors("AllowAll"); // Enable CORS
-
+app.UseAuthentication();
+app.UseAuthorization();
 app.UseEndpoints(endpoints =>
 {
     endpoints.MapControllers();

--- a/SimpleWebAppReact.csproj
+++ b/SimpleWebAppReact.csproj
@@ -7,11 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="dotenv.net" Version="3.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.33" />
     <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Twilio" Version="7.5.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
   </ItemGroup>
 

--- a/SimpleWebAppReact.csproj
+++ b/SimpleWebAppReact.csproj
@@ -7,12 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.4.1" />
     <PackageReference Include="dotenv.net" Version="3.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.33" />
     <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
     <PackageReference Include="Twilio" Version="7.5.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
   </ItemGroup>

--- a/SimpleWebAppReact.csproj
+++ b/SimpleWebAppReact.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
     <PackageReference Include="Twilio" Version="7.5.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.IdentityModel.Tokens;
 namespace SimpleWebAppReact;
 /// <summary>
 /// runs startup commands, builds front end, CORS
@@ -12,11 +11,14 @@ public class Startup
     /// <param name="configuration"></param>
     public Startup(IConfiguration configuration)
     {
+        Configuration = configuration;
     }
+    public IConfiguration Configuration { get; }  
 
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddControllers();
+        services.AddHttpClient();
 
         // Configure CORS to allow requests from React Native frontend
         services.AddCors(options =>
@@ -35,8 +37,6 @@ public class Startup
         {
             options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
             options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-            options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
-
         }).AddJwtBearer(options =>
         {
             options.Authority = "https://dev-mkdb0weeluguzopu.us.auth0.com/";

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,5 +1,6 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
 namespace SimpleWebAppReact;
-
 /// <summary>
 /// runs startup commands, builds front end, CORS
 /// </summary>
@@ -27,6 +28,22 @@ public class Startup
                        .AllowAnyHeader();
             });
         });
+        services.AddMvc();
+
+        // 1. Add Authentication Services
+        services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
+
+        }).AddJwtBearer(options =>
+        {
+            options.Authority = "https://dev-mkdb0weeluguzopu.us.auth0.com/";
+            options.Audience = "http://localhost:5128";
+        });
+
+        services.AddAuthorization();
     }
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
@@ -42,15 +59,11 @@ public class Startup
         }
 
         app.UseHttpsRedirection();
-        app.UseRouting();
-
         app.UseStaticFiles();
-
-        // Enable CORS
+        app.UseRouting();
         app.UseCors("AllowAll");
-
-        app.UseAuthorization();
-        
+        app.UseAuthentication();
+        app.UseAuthorization();        
         app.UseEndpoints(endpoints =>
         {
             endpoints.MapControllers();

--- a/appsettings.json
+++ b/appsettings.json
@@ -9,5 +9,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Auth0": {
+    "Domain": "https://dev-mkdb0weeluguzopu.us.auth0.com/",
+    "Audience": "http://localhost:5128"
+  }
 }


### PR DESCRIPTION
The error I am getting (mentioned in [this commit](https://github.com/Purdue-ACM-SIGAPP/housing-backend/commit/91957073e4cfa98ca66f20e2e5697d98fa3ae8c7) is:

`System.InvalidOperationException: No authenticationScheme was specified, and there was no DefaultChallengeScheme found. The default schemes can be set using either AddAuthentication(string defaultScheme) or AddAuthentication(Action<AuthenticationOptions> configureOptions).
   at Microsoft.AspNetCore.Authentication.AuthenticationService.ChallengeAsync(HttpContext context, String scheme, AuthenticationProperties properties)
   at Microsoft.AspNetCore.Authorization.Policy.AuthorizationMiddlewareResultHandler.HandleAsync(RequestDelegate next, HttpContext context, AuthorizationPolicy policy, PolicyAuthorizationResult authorizeResult)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)`